### PR TITLE
Add MindPin Android note app with notification capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # MindPin
-An app that will take notes from the user from an always displaying system notification, user will have options to tag the note or set reminder along
+
+MindPin is a modern Android note companion that keeps a persistent notification so you can jot down thoughts from anywhere. Notes support optional reminders and colorful tags, and can be browsed, sorted, edited, or deleted from the app.
+
+## Features
+
+- **Always-on quick capture** – A foreground notification with inline reply and quick actions lets you save notes without opening the app.
+- **Structured organization** – Tag notes with curated defaults or create your own custom labels on the fly.
+- **Smart reminders** – Attach reminder times to notes and receive actionable notifications to mark them complete.
+- **Dynamic sorting** – Switch between newest, oldest, or tag-based ordering to surface what matters.
+- **Modern UI** – Built entirely with Jetpack Compose and Material 3, supporting dynamic color and responsive layouts.
+
+## Tech stack
+
+- Kotlin + Jetpack Compose
+- Room for local persistence
+- DataStore for user preferences
+- AlarmManager backed reminders
+- Foreground service & notification actions for quick capture
+
+## Getting started
+
+1. Open the project in Android Studio (Giraffe or newer recommended).
+2. Sync Gradle and build the project.
+3. Run the `app` configuration on a device or emulator running Android 8.0 (API 26) or later.
+4. Grant the notification permission when prompted so the persistent quick-capture notification can appear.
+
+From the app you can add, edit, or delete notes, manage reminders, and sort by your preferred strategy. The notification allows capturing text instantly and launching a streamlined quick-add flow.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.3")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.3")
+    implementation("com.google.android.material:material:1.12.0")
 
     implementation("androidx.datastore:datastore-preferences:1.1.1")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,89 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp")
+}
+
+android {
+    namespace = "com.mindpin.app"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.mindpin.app"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.14"
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2024.06.00")
+
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.3")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.3")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.3")
+
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+
+    implementation("androidx.room:room-ktx:2.6.1")
+    ksp("androidx.room:room-compiler:2.6.1")
+
+    implementation("androidx.work:work-runtime-ktx:2.9.0")
+
+    implementation("androidx.core:core-splashscreen:1.0.1")
+
+    implementation("com.google.accompanist:accompanist-permissions:0.34.0")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# MindPin proguard rules

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
+    <application
+        android:name=".MindPinApplication"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.MindPin">
+        <activity
+            android:name=".QuickAddNoteActivity"
+            android:exported="false"
+            android:theme="@style/Theme.MindPin" />
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <service
+            android:name=".notification.PersistentNotificationService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
+        <receiver
+            android:name=".notification.NoteActionReceiver"
+            android:enabled="true"
+            android:exported="false" />
+
+        <receiver
+            android:name=".notification.ReminderReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.mindpin.app.action.REMINDER" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".notification.BootReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+    </application>
+
+</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application
         android:name=".MindPinApplication"

--- a/app/src/main/java/com/mindpin/app/MainActivity.kt
+++ b/app/src/main/java/com/mindpin/app/MainActivity.kt
@@ -1,0 +1,41 @@
+package com.mindpin.app
+
+import android.Manifest
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
+import androidx.core.content.ContextCompat
+import com.mindpin.app.notification.PersistentNotificationService
+import com.mindpin.app.ui.MindPinApp
+import com.mindpin.app.ui.viewmodel.MindPinViewModel
+
+class MainActivity : ComponentActivity() {
+
+    private val viewModel: MindPinViewModel by viewModels {
+        val app = application as MindPinApplication
+        MindPinViewModel.Factory(app.repository)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        PersistentNotificationService.start(this)
+
+        val requestPermissionLauncher = registerForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) { }
+
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) != android.content.pm.PackageManager.PERMISSION_GRANTED
+        ) {
+            requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+
+        setContent {
+            MindPinApp(viewModel = viewModel)
+        }
+    }
+}

--- a/app/src/main/java/com/mindpin/app/MindPinApplication.kt
+++ b/app/src/main/java/com/mindpin/app/MindPinApplication.kt
@@ -1,0 +1,49 @@
+package com.mindpin.app
+
+import android.app.Application
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.room.Room
+import com.mindpin.app.data.local.MindPinDatabase
+import com.mindpin.app.data.repository.DefaultNoteRepository
+import com.mindpin.app.data.repository.NoteRepository
+import com.mindpin.app.reminder.AlarmReminderScheduler
+import com.mindpin.app.reminder.ReminderScheduler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+private val Application.userPreferencesStore by preferencesDataStore(name = "mindpin_preferences")
+
+class MindPinApplication : Application() {
+
+    lateinit var repository: NoteRepository
+        private set
+
+    lateinit var reminderScheduler: ReminderScheduler
+        private set
+
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onCreate() {
+        super.onCreate()
+        val database = Room.databaseBuilder(
+            applicationContext,
+            MindPinDatabase::class.java,
+            "mindpin.db"
+        ).fallbackToDestructiveMigration().build()
+
+        reminderScheduler = AlarmReminderScheduler(this)
+
+        repository = DefaultNoteRepository(
+            noteDao = database.noteDao(),
+            tagDao = database.tagDao(),
+            reminderScheduler = reminderScheduler,
+            preferences = userPreferencesStore
+        )
+
+        applicationScope.launch {
+            repository.ensureDefaultTags()
+        }
+    }
+}

--- a/app/src/main/java/com/mindpin/app/QuickAddNoteActivity.kt
+++ b/app/src/main/java/com/mindpin/app/QuickAddNoteActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/app/src/main/java/com/mindpin/app/QuickAddNoteActivity.kt
+++ b/app/src/main/java/com/mindpin/app/QuickAddNoteActivity.kt
@@ -1,0 +1,211 @@
+package com.mindpin.app
+
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mindpin.app.ui.theme.MindPinTheme
+import com.mindpin.app.ui.viewmodel.MindPinViewModel
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+class QuickAddNoteActivity : ComponentActivity() {
+
+    private val viewModel: MindPinViewModel by viewModels {
+        val app = application as MindPinApplication
+        MindPinViewModel.Factory(app.repository)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MindPinTheme {
+                QuickAddNoteRoute(
+                    viewModel = viewModel,
+                    onDone = { finish() }
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun createIntent(context: Context): Intent =
+            Intent(context, QuickAddNoteActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+private fun QuickAddNoteRoute(
+    viewModel: MindPinViewModel,
+    onDone: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var content by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(TextFieldValue(""))
+    }
+    var selectedTagId by rememberSaveable { mutableStateOf<Long?>(null) }
+    var reminderAt by rememberSaveable { mutableStateOf<Long?>(null) }
+    var showTagDialog by remember { mutableStateOf(false) }
+    var newTagName by rememberSaveable { mutableStateOf("") }
+    val context = LocalContext.current
+    val formatter = remember { SimpleDateFormat("MMM dd, yyyy • HH:mm", Locale.getDefault()) }
+
+    if (showTagDialog) {
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = { showTagDialog = false },
+            title = { Text("Create tag") },
+            text = {
+                OutlinedTextField(
+                    value = newTagName,
+                    onValueChange = { newTagName = it },
+                    label = { Text("Tag name") }
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    if (newTagName.isNotBlank()) {
+                        viewModel.addTag(newTagName) { id ->
+                            selectedTagId = id
+                        }
+                        showTagDialog = false
+                        newTagName = ""
+                    }
+                }) { Text("Add") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showTagDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Quick note") },
+                actions = {
+                    TextButton(
+                        enabled = content.text.isNotBlank(),
+                        onClick = {
+                            viewModel.saveNote(content.text, selectedTagId, reminderAt)
+                            onDone()
+                        }
+                    ) {
+                        Text("Save")
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .padding(24.dp)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            OutlinedTextField(
+                value = content,
+                onValueChange = { content = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Note") }
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Tag", style = MaterialTheme.typography.titleSmall)
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    uiState.tags.forEach { tag ->
+                        FilterChip(
+                            selected = selectedTagId == tag.id,
+                            onClick = {
+                                selectedTagId = if (selectedTagId == tag.id) null else tag.id
+                            },
+                            label = { Text(tag.name) },
+                            colors = FilterChipDefaults.filterChipColors()
+                        )
+                    }
+                    TextButton(onClick = { showTagDialog = true }) {
+                        Text("New tag")
+                    }
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Reminder", style = MaterialTheme.typography.titleSmall)
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    TextButton(onClick = {
+                        val calendar = Calendar.getInstance().apply {
+                            reminderAt?.let { timeInMillis = it }
+                        }
+                        DatePickerDialog(
+                            context,
+                            { _, year, month, dayOfMonth ->
+                                calendar.set(Calendar.YEAR, year)
+                                calendar.set(Calendar.MONTH, month)
+                                calendar.set(Calendar.DAY_OF_MONTH, dayOfMonth)
+                                TimePickerDialog(
+                                    context,
+                                    { _, hour, minute ->
+                                        calendar.set(Calendar.HOUR_OF_DAY, hour)
+                                        calendar.set(Calendar.MINUTE, minute)
+                                        calendar.set(Calendar.SECOND, 0)
+                                        reminderAt = calendar.timeInMillis
+                                    },
+                                    calendar.get(Calendar.HOUR_OF_DAY),
+                                    calendar.get(Calendar.MINUTE),
+                                    true
+                                ).show()
+                            },
+                            calendar.get(Calendar.YEAR),
+                            calendar.get(Calendar.MONTH),
+                            calendar.get(Calendar.DAY_OF_MONTH)
+                        ).show()
+                    }) {
+                        Text("Pick date")
+                    }
+                    if (reminderAt != null) {
+                        TextButton(onClick = { reminderAt = null }) {
+                            Text("Clear")
+                        }
+                    }
+                }
+                reminderAt?.let {
+                    Text("Reminder set for ${formatter.format(Date(it))}", style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mindpin/app/data/local/MindPinDatabase.kt
+++ b/app/src/main/java/com/mindpin/app/data/local/MindPinDatabase.kt
@@ -1,0 +1,14 @@
+package com.mindpin.app.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [NoteEntity::class, TagEntity::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class MindPinDatabase : RoomDatabase() {
+    abstract fun noteDao(): NoteDao
+    abstract fun tagDao(): TagDao
+}

--- a/app/src/main/java/com/mindpin/app/data/local/NoteDao.kt
+++ b/app/src/main/java/com/mindpin/app/data/local/NoteDao.kt
@@ -1,0 +1,47 @@
+package com.mindpin.app.data.local
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface NoteDao {
+
+    @Transaction
+    @Query("SELECT * FROM notes WHERE is_archived = 0 ORDER BY created_at DESC")
+    fun observeNotesNewest(): Flow<List<NoteWithTag>>
+
+    @Transaction
+    @Query("SELECT * FROM notes WHERE is_archived = 0 ORDER BY created_at ASC")
+    fun observeNotesOldest(): Flow<List<NoteWithTag>>
+
+    @Transaction
+    @Query(
+        "SELECT * FROM notes WHERE is_archived = 0 ORDER BY tag_id IS NULL, tag_id, created_at DESC"
+    )
+    fun observeNotesByTag(): Flow<List<NoteWithTag>>
+
+    @Transaction
+    @Query("SELECT * FROM notes WHERE id = :noteId")
+    suspend fun getNote(noteId: Long): NoteWithTag?
+
+    @Query("SELECT * FROM notes WHERE id = :noteId")
+    suspend fun getNoteEntity(noteId: Long): NoteEntity?
+
+    @Query("SELECT * FROM notes WHERE reminder_at IS NOT NULL AND is_archived = 0")
+    suspend fun getNotesWithReminder(): List<NoteEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertNote(note: NoteEntity): Long
+
+    @Update
+    suspend fun updateNote(note: NoteEntity)
+
+    @Delete
+    suspend fun deleteNote(note: NoteEntity)
+}

--- a/app/src/main/java/com/mindpin/app/data/local/NoteEntity.kt
+++ b/app/src/main/java/com/mindpin/app/data/local/NoteEntity.kt
@@ -1,0 +1,28 @@
+package com.mindpin.app.data.local
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "notes",
+    foreignKeys = [
+        ForeignKey(
+            entity = TagEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["tag_id"],
+            onDelete = ForeignKey.SET_NULL
+        )
+    ],
+    indices = [Index("tag_id")]
+)
+data class NoteEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "content") val content: String,
+    @ColumnInfo(name = "tag_id") val tagId: Long?,
+    @ColumnInfo(name = "created_at") val createdAt: Long,
+    @ColumnInfo(name = "reminder_at") val reminderAt: Long?,
+    @ColumnInfo(name = "is_archived") val isArchived: Boolean = false
+)

--- a/app/src/main/java/com/mindpin/app/data/local/NoteWithTag.kt
+++ b/app/src/main/java/com/mindpin/app/data/local/NoteWithTag.kt
@@ -1,0 +1,13 @@
+package com.mindpin.app.data.local
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+data class NoteWithTag(
+    @Embedded val note: NoteEntity,
+    @Relation(
+        parentColumn = "tag_id",
+        entityColumn = "id"
+    )
+    val tag: TagEntity?
+)

--- a/app/src/main/java/com/mindpin/app/data/local/TagDao.kt
+++ b/app/src/main/java/com/mindpin/app/data/local/TagDao.kt
@@ -1,0 +1,20 @@
+package com.mindpin.app.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TagDao {
+
+    @Query("SELECT * FROM tags ORDER BY name")
+    fun observeTags(): Flow<List<TagEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(tag: TagEntity): Long
+
+    @Query("SELECT COUNT(*) FROM tags")
+    suspend fun count(): Int
+}

--- a/app/src/main/java/com/mindpin/app/data/local/TagEntity.kt
+++ b/app/src/main/java/com/mindpin/app/data/local/TagEntity.kt
@@ -1,0 +1,12 @@
+package com.mindpin.app.data.local
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "tags")
+data class TagEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "name") val name: String,
+    @ColumnInfo(name = "color") val color: Long
+)

--- a/app/src/main/java/com/mindpin/app/data/repository/DefaultNoteRepository.kt
+++ b/app/src/main/java/com/mindpin/app/data/repository/DefaultNoteRepository.kt
@@ -1,0 +1,144 @@
+package com.mindpin.app.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.mindpin.app.data.local.NoteDao
+import com.mindpin.app.data.local.NoteEntity
+import com.mindpin.app.data.local.NoteWithTag
+import com.mindpin.app.data.local.TagDao
+import com.mindpin.app.data.local.TagEntity
+import com.mindpin.app.model.Note
+import com.mindpin.app.model.NoteSort
+import com.mindpin.app.model.Tag
+import com.mindpin.app.reminder.ReminderScheduler
+import kotlinx.coroutines.flow.map
+
+class DefaultNoteRepository(
+    private val noteDao: NoteDao,
+    private val tagDao: TagDao,
+    private val reminderScheduler: ReminderScheduler,
+    private val preferences: DataStore<Preferences>
+) : NoteRepository {
+
+    private val sortKey = stringPreferencesKey("note_sort_order")
+
+    override fun observeNotes(sort: NoteSort): Flow<List<Note>> {
+        val source = when (sort) {
+            NoteSort.NEWEST -> noteDao.observeNotesNewest()
+            NoteSort.OLDEST -> noteDao.observeNotesOldest()
+            NoteSort.TAG -> noteDao.observeNotesByTag()
+        }
+        return source.map { notes ->
+            notes.map { it.toNote() }
+        }
+    }
+
+    override fun observeTags(): Flow<List<Tag>> =
+        tagDao.observeTags().map { entities ->
+            entities.map { it.toTag() }
+        }
+
+    override fun observeSortOrder(): Flow<NoteSort> =
+        preferences.data.map { prefs ->
+            NoteSort.fromKey(prefs[sortKey] ?: NoteSort.NEWEST.storageKey)
+        }
+
+    override suspend fun updateSortOrder(sort: NoteSort) {
+        preferences.edit { prefs ->
+            prefs[sortKey] = sort.storageKey
+        }
+    }
+
+    override suspend fun addNote(content: String, tagId: Long?, reminderAt: Long?): Long {
+        val note = NoteEntity(
+            content = content.trim(),
+            tagId = tagId,
+            createdAt = System.currentTimeMillis(),
+            reminderAt = reminderAt,
+            isArchived = false
+        )
+        val id = noteDao.upsertNote(note)
+        if (reminderAt != null) {
+            reminderScheduler.schedule(id, reminderAt, content)
+        }
+        return id
+    }
+
+    override suspend fun updateNote(note: Note) {
+        val existing = noteDao.getNoteEntity(note.id) ?: return
+        val updated = existing.copy(
+            content = note.content.trim(),
+            tagId = note.tag?.id,
+            reminderAt = note.reminderAt
+        )
+        noteDao.updateNote(updated)
+        if (note.reminderAt != null) {
+            reminderScheduler.schedule(note.id, note.reminderAt, note.content)
+        } else {
+            reminderScheduler.cancel(note.id)
+        }
+    }
+
+    override suspend fun deleteNote(noteId: Long) {
+        val existing = noteDao.getNoteEntity(noteId) ?: return
+        noteDao.deleteNote(existing)
+        reminderScheduler.cancel(noteId)
+    }
+
+    override suspend fun clearReminder(noteId: Long) {
+        val existing = noteDao.getNoteEntity(noteId) ?: return
+        val updated = existing.copy(reminderAt = null)
+        noteDao.updateNote(updated)
+        reminderScheduler.cancel(noteId)
+    }
+
+    override suspend fun addTag(name: String, color: Long): Long {
+        return tagDao.insert(
+            TagEntity(
+                name = name.trim(),
+                color = color
+            )
+        )
+    }
+
+    override suspend fun ensureDefaultTags() {
+        if (tagDao.count() > 0) return
+        listOf(
+            TagEntity(name = "Personal", color = randomPastel()),
+            TagEntity(name = "Work", color = randomPastel()),
+            TagEntity(name = "Ideas", color = randomPastel())
+        ).forEach { tagDao.insert(it) }
+    }
+
+    override suspend fun rescheduleReminders() {
+        val notes = noteDao.getNotesWithReminder()
+        notes.forEach { note ->
+            note.reminderAt?.let { reminderAt ->
+                if (reminderAt >= System.currentTimeMillis()) {
+                    reminderScheduler.schedule(note.id, reminderAt, note.content)
+                }
+            }
+        }
+    }
+
+    private fun NoteWithTag.toNote(): Note = Note(
+        id = note.id,
+        content = note.content,
+        tag = tag?.toTag(),
+        createdAt = note.createdAt,
+        reminderAt = note.reminderAt
+    )
+
+    private fun TagEntity.toTag(): Tag = Tag(
+        id = id,
+        name = name,
+        color = color
+    )
+
+    private fun randomPastel(): Long {
+        val base = listOf(0xFFBB86FCL, 0xFF6200EEL, 0xFF03DAC5L, 0xFFFFB74DL, 0xFF4FC3F7L)
+        return base.random()
+    }
+}

--- a/app/src/main/java/com/mindpin/app/data/repository/DefaultNoteRepository.kt
+++ b/app/src/main/java/com/mindpin/app/data/repository/DefaultNoteRepository.kt
@@ -13,6 +13,7 @@ import com.mindpin.app.model.Note
 import com.mindpin.app.model.NoteSort
 import com.mindpin.app.model.Tag
 import com.mindpin.app.reminder.ReminderScheduler
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 class DefaultNoteRepository(

--- a/app/src/main/java/com/mindpin/app/data/repository/NoteRepository.kt
+++ b/app/src/main/java/com/mindpin/app/data/repository/NoteRepository.kt
@@ -1,0 +1,20 @@
+package com.mindpin.app.data.repository
+
+import com.mindpin.app.model.Note
+import com.mindpin.app.model.NoteSort
+import com.mindpin.app.model.Tag
+import kotlinx.coroutines.flow.Flow
+
+interface NoteRepository {
+    fun observeNotes(sort: NoteSort): Flow<List<Note>>
+    fun observeTags(): Flow<List<Tag>>
+    fun observeSortOrder(): Flow<NoteSort>
+    suspend fun updateSortOrder(sort: NoteSort)
+    suspend fun addNote(content: String, tagId: Long?, reminderAt: Long?): Long
+    suspend fun updateNote(note: Note)
+    suspend fun deleteNote(noteId: Long)
+    suspend fun addTag(name: String, color: Long): Long
+    suspend fun ensureDefaultTags()
+    suspend fun rescheduleReminders()
+    suspend fun clearReminder(noteId: Long)
+}

--- a/app/src/main/java/com/mindpin/app/model/Note.kt
+++ b/app/src/main/java/com/mindpin/app/model/Note.kt
@@ -1,0 +1,9 @@
+package com.mindpin.app.model
+
+data class Note(
+    val id: Long,
+    val content: String,
+    val tag: Tag?,
+    val createdAt: Long,
+    val reminderAt: Long?
+)

--- a/app/src/main/java/com/mindpin/app/model/NoteSort.kt
+++ b/app/src/main/java/com/mindpin/app/model/NoteSort.kt
@@ -1,0 +1,11 @@
+package com.mindpin.app.model
+
+enum class NoteSort(val storageKey: String) {
+    NEWEST("newest"),
+    OLDEST("oldest"),
+    TAG("tag");
+
+    companion object {
+        fun fromKey(key: String): NoteSort = values().firstOrNull { it.storageKey == key } ?: NEWEST
+    }
+}

--- a/app/src/main/java/com/mindpin/app/model/Tag.kt
+++ b/app/src/main/java/com/mindpin/app/model/Tag.kt
@@ -1,0 +1,7 @@
+package com.mindpin.app.model
+
+data class Tag(
+    val id: Long,
+    val name: String,
+    val color: Long
+)

--- a/app/src/main/java/com/mindpin/app/notification/BootReceiver.kt
+++ b/app/src/main/java/com/mindpin/app/notification/BootReceiver.kt
@@ -1,0 +1,20 @@
+package com.mindpin.app.notification
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.mindpin.app.MindPinApplication
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (Intent.ACTION_BOOT_COMPLETED != intent.action) return
+        PersistentNotificationService.start(context)
+        val app = context.applicationContext as MindPinApplication
+        CoroutineScope(Dispatchers.IO).launch {
+            app.repository.rescheduleReminders()
+        }
+    }
+}

--- a/app/src/main/java/com/mindpin/app/notification/NoteActionReceiver.kt
+++ b/app/src/main/java/com/mindpin/app/notification/NoteActionReceiver.kt
@@ -1,0 +1,39 @@
+package com.mindpin.app.notification
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import androidx.core.app.RemoteInput
+import com.mindpin.app.MindPinApplication
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class NoteActionReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_QUICK_ADD) return
+        val input = RemoteInput.getResultsFromIntent(intent)
+        val content = input?.getCharSequence(KEY_CONTENT)?.toString()?.trim().orEmpty()
+        if (content.isBlank()) {
+            Toast.makeText(context, "Unable to save empty note", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val app = context.applicationContext as MindPinApplication
+        CoroutineScope(Dispatchers.IO).launch {
+            app.repository.addNote(content, tagId = null, reminderAt = null)
+        }
+        Toast.makeText(context, "Note saved", Toast.LENGTH_SHORT).show()
+    }
+
+    companion object {
+        const val KEY_CONTENT = "note_content"
+        const val ACTION_QUICK_ADD = "com.mindpin.app.action.QUICK_ADD"
+
+        fun createIntent(context: Context): Intent =
+            Intent(context, NoteActionReceiver::class.java).apply {
+                action = ACTION_QUICK_ADD
+            }
+    }
+}

--- a/app/src/main/java/com/mindpin/app/notification/PersistentNotificationService.kt
+++ b/app/src/main/java/com/mindpin/app/notification/PersistentNotificationService.kt
@@ -77,6 +77,8 @@ class PersistentNotificationService : Service() {
             .setSmallIcon(R.drawable.ic_note)
             .setContentIntent(openAppIntent)
             .setOngoing(true)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .addAction(saveAction)
             .addAction(
@@ -88,16 +90,19 @@ class PersistentNotificationService : Service() {
     }
 
     private fun createChannel() {
-        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val channel = NotificationChannel(
-            CHANNEL_ID,
-            getString(R.string.notification_channel_name),
-            NotificationManager.IMPORTANCE_DEFAULT
-        ).apply {
-            description = getString(R.string.notification_channel_description)
-            setShowBadge(false)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.notification_channel_name),
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = getString(R.string.notification_channel_description)
+                setShowBadge(false)
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+            }
+            manager.createNotificationChannel(channel)
         }
-        manager.createNotificationChannel(channel)
     }
 
     override fun onDestroy() {
@@ -110,7 +115,11 @@ class PersistentNotificationService : Service() {
 
         fun start(context: Context) {
             val intent = Intent(context, PersistentNotificationService::class.java)
-            context.startForegroundService(intent)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
         }
     }
 }

--- a/app/src/main/java/com/mindpin/app/notification/PersistentNotificationService.kt
+++ b/app/src/main/java/com/mindpin/app/notification/PersistentNotificationService.kt
@@ -1,0 +1,105 @@
+package com.mindpin.app.notification
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.RemoteInput
+import com.mindpin.app.MainActivity
+import com.mindpin.app.QuickAddNoteActivity
+import com.mindpin.app.R
+
+class PersistentNotificationService : Service() {
+
+    override fun onCreate() {
+        super.onCreate()
+        createChannel()
+        startForeground(NOTIFICATION_ID, buildNotification())
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun buildNotification(): Notification {
+        val openAppIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val quickAddIntent = PendingIntent.getActivity(
+            this,
+            1,
+            QuickAddNoteActivity.createIntent(this),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val remoteInput = RemoteInput.Builder(NoteActionReceiver.KEY_CONTENT)
+            .setLabel(getString(R.string.notification_add_note))
+            .build()
+
+        val saveIntent = PendingIntent.getBroadcast(
+            this,
+            2,
+            NoteActionReceiver.createIntent(this),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val saveAction = NotificationCompat.Action.Builder(
+            R.drawable.ic_note_add,
+            getString(R.string.notification_add_note),
+            saveIntent
+        ).addRemoteInput(remoteInput).build()
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.app_name))
+            .setContentText(getString(R.string.notification_add_note))
+            .setSmallIcon(R.drawable.ic_note)
+            .setContentIntent(openAppIntent)
+            .setOngoing(true)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .addAction(saveAction)
+            .addAction(
+                R.drawable.ic_note,
+                getString(R.string.notification_open_app),
+                quickAddIntent
+            )
+            .build()
+    }
+
+    private fun createChannel() {
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.notification_channel_name),
+            NotificationManager.IMPORTANCE_DEFAULT
+        ).apply {
+            description = getString(R.string.notification_channel_description)
+            setShowBadge(false)
+        }
+        manager.createNotificationChannel(channel)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "mindpin_notes"
+        private const val NOTIFICATION_ID = 1
+
+        fun start(context: Context) {
+            val intent = Intent(context, PersistentNotificationService::class.java)
+            context.startForegroundService(intent)
+        }
+    }
+}

--- a/app/src/main/java/com/mindpin/app/notification/PersistentNotificationService.kt
+++ b/app/src/main/java/com/mindpin/app/notification/PersistentNotificationService.kt
@@ -3,10 +3,12 @@ package com.mindpin.app.notification
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
-import android.app.Service
 import android.app.PendingIntent
+import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
@@ -19,7 +21,16 @@ class PersistentNotificationService : Service() {
     override fun onCreate() {
         super.onCreate()
         createChannel()
-        startForeground(NOTIFICATION_ID, buildNotification())
+        val notification = buildNotification()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/java/com/mindpin/app/notification/ReminderReceiver.kt
+++ b/app/src/main/java/com/mindpin/app/notification/ReminderReceiver.kt
@@ -1,0 +1,97 @@
+package com.mindpin.app.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import com.mindpin.app.MainActivity
+import com.mindpin.app.MindPinApplication
+import com.mindpin.app.R
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class ReminderReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action
+        val noteId = intent.getLongExtra(EXTRA_NOTE_ID, -1)
+        val content = intent.getStringExtra(EXTRA_NOTE_CONTENT).orEmpty()
+        if (noteId == -1L) return
+
+        if (action == ACTION_MARK_DONE) {
+            val app = context.applicationContext as MindPinApplication
+            CoroutineScope(Dispatchers.IO).launch {
+                app.repository.clearReminder(noteId)
+            }
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.cancel(noteId.toInt())
+            return
+        }
+
+        showReminderNotification(context, noteId, content)
+    }
+
+    private fun showReminderNotification(context: Context, noteId: Long, content: String) {
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            context.getString(R.string.notification_channel_name),
+            NotificationManager.IMPORTANCE_HIGH
+        )
+        manager.createNotificationChannel(channel)
+
+        val openIntent = PendingIntent.getActivity(
+            context,
+            noteId.toInt(),
+            Intent(context, MainActivity::class.java),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val markDoneIntent = PendingIntent.getBroadcast(
+            context,
+            (noteId + 1000).toInt(),
+            createMarkDoneIntent(context, noteId),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setContentTitle(context.getString(R.string.app_name))
+            .setContentText(content)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setAutoCancel(true)
+            .setContentIntent(openIntent)
+            .addAction(
+                R.drawable.ic_check,
+                context.getString(R.string.notification_mark_done),
+                markDoneIntent
+            )
+            .build()
+
+        manager.notify(noteId.toInt(), notification)
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "mindpin_reminder"
+        const val EXTRA_NOTE_ID = "extra_note_id"
+        const val EXTRA_NOTE_CONTENT = "extra_note_content"
+        const val ACTION_REMINDER = "com.mindpin.app.action.REMINDER"
+        const val ACTION_MARK_DONE = "com.mindpin.app.action.MARK_DONE"
+
+        fun createIntent(context: Context, noteId: Long, content: String): Intent =
+            Intent(context, ReminderReceiver::class.java).apply {
+                action = ACTION_REMINDER
+                putExtra(EXTRA_NOTE_ID, noteId)
+                putExtra(EXTRA_NOTE_CONTENT, content)
+            }
+
+        fun createMarkDoneIntent(context: Context, noteId: Long): Intent =
+            Intent(context, ReminderReceiver::class.java).apply {
+                action = ACTION_MARK_DONE
+                putExtra(EXTRA_NOTE_ID, noteId)
+            }
+    }
+}

--- a/app/src/main/java/com/mindpin/app/reminder/AlarmReminderScheduler.kt
+++ b/app/src/main/java/com/mindpin/app/reminder/AlarmReminderScheduler.kt
@@ -1,0 +1,41 @@
+package com.mindpin.app.reminder
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import com.mindpin.app.notification.ReminderReceiver
+import java.util.concurrent.TimeUnit
+
+class AlarmReminderScheduler(private val context: Context) : ReminderScheduler {
+
+    private val alarmManager: AlarmManager =
+        context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+    override fun schedule(noteId: Long, triggerAtMillis: Long, content: String) {
+        val intent = ReminderReceiver.createIntent(context, noteId, content)
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            noteId.toInt(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        alarmManager.setExactAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            triggerAtMillis,
+            pendingIntent
+        )
+    }
+
+    override fun cancel(noteId: Long) {
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            noteId.toInt(),
+            ReminderReceiver.createIntent(context, noteId, ""),
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+        )
+        pendingIntent?.let { alarmManager.cancel(it) }
+    }
+
+}

--- a/app/src/main/java/com/mindpin/app/reminder/ReminderScheduler.kt
+++ b/app/src/main/java/com/mindpin/app/reminder/ReminderScheduler.kt
@@ -1,0 +1,6 @@
+package com.mindpin.app.reminder
+
+interface ReminderScheduler {
+    fun schedule(noteId: Long, triggerAtMillis: Long, content: String)
+    fun cancel(noteId: Long)
+}

--- a/app/src/main/java/com/mindpin/app/ui/MindPinApp.kt
+++ b/app/src/main/java/com/mindpin/app/ui/MindPinApp.kt
@@ -1,0 +1,33 @@
+package com.mindpin.app.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mindpin.app.ui.theme.MindPinTheme
+import com.mindpin.app.ui.viewmodel.MindPinViewModel
+
+@Composable
+fun MindPinApp(viewModel: MindPinViewModel) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    MindPinTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            NoteListScreen(
+                state = uiState,
+                onAddNote = { viewModel.showAddSheet() },
+                onEditNote = { viewModel.showAddSheet(it) },
+                onDeleteNote = { viewModel.deleteNote(it) },
+                onSortChange = { viewModel.updateSort(it) },
+                onReminderClear = { viewModel.clearReminder(it) },
+                onSaveNote = { content, tagId, reminderAt ->
+                    viewModel.saveNote(content, tagId, reminderAt)
+                },
+                onDismissEditor = { viewModel.hideAddSheet() },
+                onCreateTag = { name, onCreated -> viewModel.addTag(name, onCreated) }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/mindpin/app/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/mindpin/app/ui/NoteListScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/mindpin/app/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/mindpin/app/ui/NoteListScreen.kt
@@ -1,0 +1,218 @@
+package com.mindpin.app.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Sort
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallTopAppBar
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.mindpin.app.model.Note
+import com.mindpin.app.model.NoteSort
+import com.mindpin.app.ui.components.NoteEditorSheet
+import com.mindpin.app.ui.state.NoteListUiState
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NoteListScreen(
+    state: NoteListUiState,
+    onAddNote: () -> Unit,
+    onEditNote: (Note) -> Unit,
+    onDeleteNote: (Long) -> Unit,
+    onSortChange: (NoteSort) -> Unit,
+    onReminderClear: (Long) -> Unit,
+    onSaveNote: (String, Long?, Long?) -> Unit,
+    onDismissEditor: () -> Unit,
+    onCreateTag: (String, (Long) -> Unit) -> Unit
+) {
+    var isSortMenuExpanded by remember { mutableStateOf(false) }
+    Scaffold(
+        topBar = {
+            SmallTopAppBar(
+                title = { Text("MindPin") },
+                actions = {
+                    IconButton(onClick = { isSortMenuExpanded = true }) {
+                        Icon(Icons.Default.Sort, contentDescription = "Sort")
+                    }
+                    DropdownMenu(
+                        expanded = isSortMenuExpanded,
+                        onDismissRequest = { isSortMenuExpanded = false }
+                    ) {
+                        NoteSort.entries.forEach { sort ->
+                            DropdownMenuItem(
+                                text = { Text(sort.label()) },
+                                onClick = {
+                                    isSortMenuExpanded = false
+                                    onSortChange(sort)
+                                }
+                            )
+                        }
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onAddNote) {
+                Icon(Icons.Default.Add, contentDescription = "Add note")
+            }
+        }
+    ) { innerPadding ->
+        if (state.notes.isEmpty()) {
+            EmptyState(modifier = Modifier.padding(innerPadding))
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize(),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(state.notes, key = { it.id }) { note ->
+                    NoteCard(
+                        note = note,
+                        onEdit = { onEditNote(note) },
+                        onDelete = { onDeleteNote(note.id) },
+                        onReminderClear = { onReminderClear(note.id) }
+                    )
+                }
+            }
+        }
+    }
+
+    if (state.isAddEditVisible) {
+        val tags = state.tags
+        NoteEditorSheet(
+            note = state.editingNote,
+            tags = tags,
+            onDismiss = onDismissEditor,
+            onSave = { content, tagId, reminderAt ->
+                onSaveNote(content, tagId, reminderAt)
+            },
+            onCreateTag = onCreateTag
+        )
+    }
+}
+
+@Composable
+private fun NoteSort.label(): String = when (this) {
+    NoteSort.NEWEST -> "Newest first"
+    NoteSort.OLDEST -> "Oldest first"
+    NoteSort.TAG -> "By tag"
+}
+
+@Composable
+private fun EmptyState(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Capture every thought",
+            style = MaterialTheme.typography.titleMedium
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Tap the + button or use the notification to add your first note.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun NoteCard(
+    note: Note,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    onReminderClear: () -> Unit
+) {
+    Surface(
+        tonalElevation = 2.dp,
+        shape = MaterialTheme.shapes.medium
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = note.content,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 6,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                note.tag?.let { tag ->
+                    AssistChip(
+                        onClick = {},
+                        label = { Text(tag.name) },
+                        colors = AssistChipDefaults.assistChipColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            labelColor = MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                IconButton(onClick = onEdit) {
+                    Icon(Icons.Default.Edit, contentDescription = "Edit")
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(Icons.Default.Delete, contentDescription = "Delete")
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            val formatter = remember { SimpleDateFormat("MMM dd, yyyy • HH:mm", Locale.getDefault()) }
+            Text(
+                text = "Created ${formatter.format(Date(note.createdAt))}",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            note.reminderAt?.let { reminder ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Reminder ${formatter.format(Date(reminder))}",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                TextButton(onClick = onReminderClear) {
+                    Text("Clear reminder")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mindpin/app/ui/components/NoteEditorSheet.kt
+++ b/app/src/main/java/com/mindpin/app/ui/components/NoteEditorSheet.kt
@@ -1,0 +1,182 @@
+package com.mindpin.app.ui.components
+
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.mindpin.app.model.Note
+import com.mindpin.app.model.Tag
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun NoteEditorSheet(
+    note: Note?,
+    tags: List<Tag>,
+    onDismiss: () -> Unit,
+    onSave: (content: String, tagId: Long?, reminderAt: Long?) -> Unit,
+    onCreateTag: (String, (Long) -> Unit) -> Unit
+) {
+    val context = LocalContext.current
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    var content by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(TextFieldValue(note?.content.orEmpty()))
+    }
+    var selectedTagId by rememberSaveable { mutableStateOf(note?.tag?.id) }
+    var reminderAt by rememberSaveable { mutableStateOf(note?.reminderAt) }
+    var showTagDialog by remember { mutableStateOf(false) }
+    var newTagName by rememberSaveable { mutableStateOf("") }
+
+    val formatter = remember { SimpleDateFormat("MMM dd, yyyy • HH:mm", Locale.getDefault()) }
+
+    if (showTagDialog) {
+        AlertDialog(
+            onDismissRequest = { showTagDialog = false },
+            title = { Text("Create tag") },
+            text = {
+                OutlinedTextField(
+                    value = newTagName,
+                    onValueChange = { newTagName = it },
+                    label = { Text("Tag name") }
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    if (newTagName.isNotBlank()) {
+                        onCreateTag(newTagName) { id ->
+                            selectedTagId = id
+                        }
+                        showTagDialog = false
+                        newTagName = ""
+                    }
+                }) {
+                    Text("Add")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showTagDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(modifier = Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Text(text = if (note == null) "New note" else "Edit note", style = MaterialTheme.typography.titleMedium)
+            OutlinedTextField(
+                value = content,
+                onValueChange = { content = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Note") },
+                supportingText = { Text("Add a short note or idea") }
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Tags", style = MaterialTheme.typography.titleSmall)
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    tags.forEach { tag ->
+                        FilterChip(
+                            selected = selectedTagId == tag.id,
+                            onClick = {
+                                selectedTagId = if (selectedTagId == tag.id) null else tag.id
+                            },
+                            label = { Text(tag.name) },
+                            colors = FilterChipDefaults.filterChipColors()
+                        )
+                    }
+                    TextButton(onClick = { showTagDialog = true }) {
+                        Text("New tag")
+                    }
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Reminder", style = MaterialTheme.typography.titleSmall)
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    TextButton(onClick = {
+                        val calendar = Calendar.getInstance().apply {
+                            reminderAt?.let { timeInMillis = it }
+                        }
+                        DatePickerDialog(
+                            context,
+                            { _, year, month, dayOfMonth ->
+                                calendar.set(Calendar.YEAR, year)
+                                calendar.set(Calendar.MONTH, month)
+                                calendar.set(Calendar.DAY_OF_MONTH, dayOfMonth)
+                                TimePickerDialog(
+                                    context,
+                                    { _, hour, minute ->
+                                        calendar.set(Calendar.HOUR_OF_DAY, hour)
+                                        calendar.set(Calendar.MINUTE, minute)
+                                        calendar.set(Calendar.SECOND, 0)
+                                        reminderAt = calendar.timeInMillis
+                                    },
+                                    calendar.get(Calendar.HOUR_OF_DAY),
+                                    calendar.get(Calendar.MINUTE),
+                                    true
+                                ).show()
+                            },
+                            calendar.get(Calendar.YEAR),
+                            calendar.get(Calendar.MONTH),
+                            calendar.get(Calendar.DAY_OF_MONTH)
+                        ).show()
+                    }) {
+                        Text("Pick date")
+                    }
+                    if (reminderAt != null) {
+                        TextButton(onClick = { reminderAt = null }) {
+                            Text("Clear")
+                        }
+                    }
+                }
+                reminderAt?.let {
+                    Text("Reminder set for ${formatter.format(Date(it))}", style = MaterialTheme.typography.bodySmall)
+                }
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                TextButton(onClick = onDismiss) { Text("Cancel") }
+                Spacer(modifier = Modifier.weight(1f))
+                Button(
+                    enabled = content.text.isNotBlank(),
+                    onClick = {
+                        onSave(content.text, selectedTagId, reminderAt)
+                    }
+                ) {
+                    Text("Save")
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/mindpin/app/ui/state/NoteListUiState.kt
+++ b/app/src/main/java/com/mindpin/app/ui/state/NoteListUiState.kt
@@ -1,0 +1,13 @@
+package com.mindpin.app.ui.state
+
+import com.mindpin.app.model.Note
+import com.mindpin.app.model.NoteSort
+import com.mindpin.app.model.Tag
+
+data class NoteListUiState(
+    val notes: List<Note> = emptyList(),
+    val tags: List<Tag> = emptyList(),
+    val selectedSort: NoteSort = NoteSort.NEWEST,
+    val isAddEditVisible: Boolean = false,
+    val editingNote: Note? = null
+)

--- a/app/src/main/java/com/mindpin/app/ui/theme/Theme.kt
+++ b/app/src/main/java/com/mindpin/app/ui/theme/Theme.kt
@@ -1,0 +1,36 @@
+package com.mindpin.app.ui.theme
+
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+private val DarkColors = darkColorScheme()
+private val LightColors = lightColorScheme()
+
+@Composable
+fun MindPinTheme(
+    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val context = LocalContext.current
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            if (useDarkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        useDarkTheme -> DarkColors
+        else -> LightColors
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = MaterialTheme.typography,
+        content = content
+    )
+}

--- a/app/src/main/java/com/mindpin/app/ui/viewmodel/MindPinViewModel.kt
+++ b/app/src/main/java/com/mindpin/app/ui/viewmodel/MindPinViewModel.kt
@@ -1,0 +1,121 @@
+package com.mindpin.app.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.mindpin.app.data.repository.NoteRepository
+import com.mindpin.app.model.Note
+import com.mindpin.app.model.NoteSort
+import com.mindpin.app.ui.state.NoteListUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class MindPinViewModel(
+    private val repository: NoteRepository
+) : ViewModel() {
+
+    private val isAddEditVisible = MutableStateFlow(false)
+    private val editingNote = MutableStateFlow<Note?>(null)
+
+    private val sortOrder = repository.observeSortOrder()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, NoteSort.NEWEST)
+
+    private val tags = repository.observeTags()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    private val notes = sortOrder.flatMapLatest { sort ->
+        repository.observeNotes(sort)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    val uiState = combine(sortOrder, tags, notes, isAddEditVisible, editingNote) { sort, tags, notes, visible, editing ->
+        NoteListUiState(
+            notes = notes,
+            tags = tags,
+            selectedSort = sort,
+            isAddEditVisible = visible,
+            editingNote = editing
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, NoteListUiState())
+
+    fun showAddSheet(note: Note? = null) {
+        editingNote.value = note
+        isAddEditVisible.value = true
+    }
+
+    fun hideAddSheet() {
+        isAddEditVisible.value = false
+        editingNote.value = null
+    }
+
+    fun updateSort(sort: NoteSort) {
+        viewModelScope.launch {
+            repository.updateSortOrder(sort)
+        }
+    }
+
+    fun saveNote(content: String, tagId: Long?, reminderAt: Long?) {
+        val editing = editingNote.value
+        if (editing == null) {
+            viewModelScope.launch {
+                repository.addNote(content, tagId, reminderAt)
+            }
+        } else {
+            viewModelScope.launch {
+                val selectedTag = tagId?.let { id -> uiState.value.tags.firstOrNull { it.id == id } }
+                repository.updateNote(
+                    editing.copy(
+                        content = content,
+                        tag = selectedTag,
+                        reminderAt = reminderAt
+                    )
+                )
+            }
+        }
+        hideAddSheet()
+    }
+
+    fun deleteNote(noteId: Long) {
+        viewModelScope.launch {
+            repository.deleteNote(noteId)
+        }
+    }
+
+    fun clearReminder(noteId: Long) {
+        viewModelScope.launch {
+            repository.clearReminder(noteId)
+        }
+    }
+
+    fun addTag(name: String, onCreated: (Long) -> Unit = {}) {
+        if (name.isBlank()) return
+        viewModelScope.launch {
+            val color = palette.random()
+            val id = repository.addTag(name.trim(), color)
+            onCreated(id)
+        }
+    }
+
+    private val palette = listOf(
+        0xFF6750A4L,
+        0xFF7D5260L,
+        0xFF386A20L,
+        0xFF006494L,
+        0xFF964F4CL
+    )
+
+    class Factory(
+        private val repository: NoteRepository
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(MindPinViewModel::class.java)) {
+                return MindPinViewModel(repository) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_check.xml
+++ b/app/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19l12,-12 -1.41,-1.41z" />
+</vector>

--- a/app/src/main/res/drawable/ic_note.xml
+++ b/app/src/main/res/drawable/ic_note.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,5c0,-1.1 0.9,-2 2,-2h8l6,6v10c0,1.1 -0.9,2 -2,2H5c-1.1,0 -2,-0.9 -2,-2V5zm12,0H5v14h14V9h-4V5z" />
+</vector>

--- a/app/src/main/res/drawable/ic_note_add.xml
+++ b/app/src/main/res/drawable/ic_note_add.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M14,2H6c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V8l-6,-6zm1,14h-2v2h-2v-2H9v-2h2v-2h2v2h2v2zm-3,-7V3.5L18.5,9H12z" />
+</vector>

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.9,2 2,2zm6,-6v-5c0,-3.07 -1.63,-5.64 -4.5,-6.32V4c0,-0.83 -0.67,-1.5 -1.5,-1.5S10.5,3.17 10.5,4v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z" />
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_note" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_note" />
+</adaptive-icon>

--- a/app/src/main/res/values/ic_launcher_background.xml
+++ b/app/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,3 @@
+<resources>
+    <color name="ic_launcher_background">#FFFBFE</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<resources>
+    <string name="app_name">MindPin</string>
+    <string name="notification_channel_name">MindPin Notes</string>
+    <string name="notification_channel_description">Add notes quickly from notification</string>
+    <string name="notification_add_note">Add note</string>
+    <string name="notification_open_app">Open MindPin</string>
+    <string name="notification_mark_done">Mark reminder done</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,8 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.MindPin" parent="Theme.Material3.DynamicColors.DayNight">
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,8 +1,3 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="Theme.MindPin" parent="Theme.Material3.DynamicColors.DayNight">
-        <item name="android:statusBarColor">?attr/colorPrimary</item>
-        <item name="android:navigationBarColor">?attr/colorSurface</item>
-        <item name="android:windowLightStatusBar">true</item>
-        <item name="android:windowLightNavigationBar">true</item>
-    </style>
+<resources>
+    <style name="Theme.MindPin" parent="Theme.Material3.DayNight.NoActionBar" />
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("com.android.application") version "8.4.2" apply false
+    id("com.android.library") version "8.4.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+    id("com.google.devtools.ksp") version "1.9.24-1.0.20" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.enableJetifier=true
+kotlin.code.style=official

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "MindPin"
+include(":app")


### PR DESCRIPTION
## Summary
- set up a modern Compose-based Android app module with Room persistence, DataStore preferences, and AlarmManager reminders
- add persistent notification and quick add activity for capturing tagged notes with inline actions
- implement note list UI with sorting, tag management, reminder scheduling, and quick editor sheet

## Testing
- not run (build tools unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e184c76e1883218fc6145bef44d468